### PR TITLE
Python 3 compatibility

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,19 @@
+[run]
+branch = True
+source = grokcore.content
+
+[report]
+precision = 2
+omit = */interfaces.py
+       */interfaces/*
+       */tests.py
+       */tests/*
+
+[html]
+directory = htmlcov
+
+[paths]
+source =
+   src/grokcore/content
+   .tox/*/lib/python*/site-packages/grokcore/content
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,12 @@
 __pycache__
 src/*.egg-info
 
+.coverage
+.coverage.*
 .installed.cfg
+.tox
 bin
+coverage.xml
 develop-eggs
+htmlcov/
 parts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 python:
-    - 2.6
-    - 2.7
+    - 3.5
+sudo: false
+env:
+    - TOXENV=py27
+    - TOXENV=py34
+    - TOXENV=py35
 install:
-    - python bootstrap.py
-    - bin/buildout
+    - pip install tox
 script:
-    - bin/test -v1
+    - tox
 notifications:
     email: false

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,10 @@ Changes
 - Use ``zope.interface.implementer`` decorator instead of
   ``zope.interface.implements`` with classes to support Python 3.
 
+- Express support for Python 2.7, 3.4 and 3.5.
+
+- Use tox for test orchestration.
+
 
 1.3.1 (2016-01-29)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changes
 1.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Use ``zope.interface.implementer`` decorator instead of
+  ``zope.interface.implements`` with classes to support Python 3.
 
 
 1.3.1 (2016-01-29)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     license='ZPL',
     install_requires=install_requires,
     tests_require=tests_require,
+    test_suite='grokcore.content.tests.collect_tests',
     extras_require={'test': tests_require},
     packages=find_packages('src'),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ install_requires = [
     'zope.container',
     'zope.interface',
     'zope.lifecycleevent',
-    ]
+]
 
 tests_require = [
     'zope.testing',
     'zope.component',
-    ]
+]
 
 setup(
     name='grokcore.content',
@@ -46,5 +46,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Zope Public License',
         'Programming Language :: Python',
-        'Framework :: Zope3'],
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Framework :: Zope3'
+    ],
 )

--- a/src/grokcore/content/components.py
+++ b/src/grokcore/content/components.py
@@ -20,9 +20,10 @@ from persistent.list import PersistentList
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.container.btree import BTreeContainer
 from zope.container.contained import Contained, notifyContainerModified
-from zope.interface import implements
+from zope.interface import implementer
 
 
+@implementer(IAttributeAnnotatable, interfaces.IContext)
 class Model(Contained, persistent.Persistent):
     # XXX Inheritance order is important here. If we reverse this,
     # then containers can't be models anymore because no unambigous MRO
@@ -41,9 +42,9 @@ class Model(Contained, persistent.Persistent):
     automatically be made the `grok.context()` of each of the views.
 
     """
-    implements(IAttributeAnnotatable, interfaces.IContext)
 
 
+@implementer(IAttributeAnnotatable, interfaces.IContainer)
 class Container(BTreeContainer):
     """The base class for containers in Grok applications.
 
@@ -62,9 +63,9 @@ class Container(BTreeContainer):
     or 'address') under which that item has been stored.
 
     """
-    implements(IAttributeAnnotatable, interfaces.IContainer)
 
 
+@implementer(interfaces.IOrderedContainer)
 class OrderedContainer(Container):
     """A Grok container that remembers the order of its items.
 
@@ -75,7 +76,6 @@ class OrderedContainer(Container):
     way of changing the order is to call the `updateOrder()` method.
 
     """
-    implements(interfaces.IOrderedContainer)
 
     def __init__(self):
         super(OrderedContainer, self).__init__()

--- a/src/grokcore/content/interfaces.py
+++ b/src/grokcore/content/interfaces.py
@@ -36,5 +36,7 @@ class IObjectEditedEvent(IObjectModifiedEvent):
     """
 
 
+@zope.interface.implementer(IObjectEditedEvent)
 class ObjectEditedEvent(ObjectModifiedEvent):
-    zope.interface.implements(IObjectEditedEvent)
+    """One of the attributes of the object was edited.
+    """

--- a/src/grokcore/content/tests/__init__.py
+++ b/src/grokcore/content/tests/__init__.py
@@ -1,1 +1,16 @@
 # make this directory a package
+import grokcore.content.tests.test_container
+import grokcore.content.tests.test_container_event
+import grokcore.content.tests.test_orderedcontainer
+import grokcore.content.tests.test_verify_containers
+import unittest
+
+
+def collect_tests():
+    """Combine all test suites to have one entry point."""
+    return unittest.TestSuite((
+        grokcore.content.tests.test_container.test_suite(),
+        grokcore.content.tests.test_container_event.test_suite(),
+        grokcore.content.tests.test_orderedcontainer.test_suite(),
+        grokcore.content.tests.test_verify_containers.test_suite(),
+    ))

--- a/src/grokcore/content/tests/test_container.py
+++ b/src/grokcore/content/tests/test_container.py
@@ -18,15 +18,15 @@ with the __parent__ attribute being set, we better make sure
 this doesn't happen again:
 
     >>> skull = Bone()
-    >>> print skull.__parent__
+    >>> print(skull.__parent__)
     None
-    >>> print skull.__name__
+    >>> print(skull.__name__)
     None
     >>> bag['skull'] = skull
     >>> skull.__parent__
     <grokcore.content.tests.test_container.BoneBag object at 0x...>
-    >>> skull.__name__
-    u'skull'
+    >>> 'skull name';skull.__name__
+    'skull name'...'skull'
 
 """
 

--- a/src/grokcore/content/tests/test_container.py
+++ b/src/grokcore/content/tests/test_container.py
@@ -25,6 +25,11 @@ this doesn't happen again:
     >>> bag['skull'] = skull
     >>> skull.__parent__
     <grokcore.content.tests.test_container.BoneBag object at 0x...>
+    
+Note how we prefix the print output in order to have the ellipsis work as 
+the output for the __name__ is slightly different between python 2 and
+python 3.
+    
     >>> 'skull name';skull.__name__
     'skull name'...'skull'
 

--- a/src/grokcore/content/tests/test_container_event.py
+++ b/src/grokcore/content/tests/test_container_event.py
@@ -41,7 +41,7 @@ class Bone(Model):
 
 @subscribe(OrderedBones, IContainerModifiedEvent)
 def container_changed(object, event):
-    print 'Container has changed!'
+    print('Container has changed!')
 
 
 def test_suite():

--- a/src/grokcore/content/tests/test_orderedcontainer.py
+++ b/src/grokcore/content/tests/test_orderedcontainer.py
@@ -56,7 +56,7 @@ Adding a new object under an existing key, raises a DuplicationError::
   >>> bones['shin'] = Bone('Another Shin Bone')
   Traceback (most recent call last):
   ...
-  KeyError: u'shin'
+  KeyError: ...'shin'
 
 Reordering with a wrong set of keys should fail::
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist = coverage-clean, py27, py34, py35, coverage-report
+
+[testenv]
+commands =
+    coverage run setup.py test
+setenv =
+  COVERAGE_FILE=.coverage.{envname}
+deps =
+    coverage
+
+[testenv:coverage-clean]
+deps = coverage
+setenv =
+  COVERAGE_FILE=.coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:coverage-report]
+deps = coverage
+setenv =
+  COVERAGE_FILE=.coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report
+    coverage html
+    coverage xml


### PR DESCRIPTION
According to https://zope3.pov.lt/py3/ this package blocks at least three grok packages on their way to Python 3. In principal the use of `zope.interface.implements` had to be changed to the `zope.interface.implementer` decorator. I also added tox and coverage to the project to successfully port it to Python 3.

@thefunny42 : It would be nice, if you could review the PR, merge and release it, so that the new version can be used as soon as possible for further porting to Python 3.
